### PR TITLE
CLI Enhancements

### DIFF
--- a/.ci/build-docs
+++ b/.ci/build-docs
@@ -30,5 +30,5 @@ echo "bundle exec jazzy --config .jazzy.json"
 bundle exec jazzy --config .jazzy.json
 
 echo "--- :aws: Upload"
-echo 'aws s3 sync --acl public-read docs "s3://procedure.kit.run/$PROCEDUREKIT_BRANCH"'
-aws s3 sync --acl public-read docs "s3://procedure.kit.run/$PROCEDUREKIT_BRANCH"
+echo 'aws s3 sync docs "s3://procedure.kit.run/$PROCEDUREKIT_BRANCH" --acl public-read --delete'
+aws s3 sync docs "s3://procedure.kit.run/$PROCEDUREKIT_BRANCH" --acl public-read --delete

--- a/.ci/build-docs
+++ b/.ci/build-docs
@@ -26,8 +26,8 @@ echo "--- Jazzy ProcedureKit"
 echo "cd sources/ProcedureKit"
 cd "sources/ProcedureKit"
 
-echo "bundle exec jazzy --config .jazzy.json"
-bundle exec jazzy --config .jazzy.json
+echo "bundle exec jazzy --clean --config .jazzy.json"
+bundle exec jazzy --clean --config .jazzy.json
 
 echo "--- :aws: Upload"
 echo 'aws s3 sync docs "s3://procedure.kit.run/$PROCEDUREKIT_BRANCH" --acl public-read --delete'

--- a/.ci/build-docs
+++ b/.ci/build-docs
@@ -26,8 +26,8 @@ echo "--- Jazzy ProcedureKit"
 echo "cd sources/ProcedureKit"
 cd "sources/ProcedureKit"
 
-echo "bundle exec jazzy --clean --config .jazzy.json"
-bundle exec jazzy --clean --config .jazzy.json
+echo "bundle exec jazzy --clean --output docs --config .jazzy.json"
+bundle exec jazzy --clean --output docs --config .jazzy.json
 
 echo "--- :aws: Upload"
 echo 'aws s3 sync docs "s3://procedure.kit.run/$PROCEDUREKIT_BRANCH" --acl public-read --delete'


### PR DESCRIPTION
- AWS S3 Upload: Add `--delete` flag
Ensures that the destination (the S3 path) matches source exactly ([by removing any files that do not exist in source](http://docs.aws.amazon.com/cli/latest/reference/s3/sync.html)).

- Jazzy: Add `--clean` flag
Ensure that Jazzy cleans the output (docs) directory when run.

- Jazzy: Explicitly specify the expected output directory